### PR TITLE
Add CS5 to RunInIndesign.sublime-settings

### DIFF
--- a/RunInIndesign.sublime-settings
+++ b/RunInIndesign.sublime-settings
@@ -5,6 +5,10 @@
             "name": "(default)"
         },
         {
+            "identifier": "CS5",
+            "name": "CS5"
+        },
+        {
             "identifier": "CS6",
             "name": "CS6"
         },


### PR DESCRIPTION
I did this change manually to this file in my Sublime package, and it ran on CS5 just fine.  Figured it should be in the plugin?

Awesome plugin btw ;)
