### PR TITLE
Fixing check of res variable

### DIFF
--- a/utils/jsRunner.jsx
+++ b/utils/jsRunner.jsx
@@ -20,7 +20,7 @@ $.writeln = function(){
 try{
 	//$.write($.sblimeRunner.runFile);
 	var res=$.evalFile($.sblimeRunner.runFile);
-	if (res!==undefined){
+	if (res !== undefined && res !== null){
 		$.writeln('Indesign returned: '+res.toString());
 	}
 	$.writeln('[Finished]');


### PR DESCRIPTION
Hi there,

just a quick fix. `res` can turn out to be `null` in some cases, in which case the next line throws an error.